### PR TITLE
Added redis, rabbitmq, restructured command groups/commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Development
+dev/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Here are the reasons for the required modules:
 - ncclient                  - Obvious one... Handles the low networking level of SSH/NETCONF
 - click and click-plugins   - Click is an awesome tool to build CLI applications, netconf-tool is a CLI application
 - loguru                    - Best logging module out there, I don't like exit() and print() statements...
+- redis                     - Used to test notification events against a redis pubsub environment
+- pika                      - Used to test notification events against a rabbitmq environment
+- xmltodict                 - Allow lazy conversion from XML to JSON for formatting arguments on some commands
 
 This CLI application is built to load plugins using the entrypoint of netconf-tools so I may look into adding more functionality once I move over all my developer focused NETCONF tasks to this CLI project.
 
@@ -20,17 +23,17 @@ Use NETCONF_TOOL_USERNAME and NETCONF_TOOL_PASSWORD environment variables to pre
 
 ## Feature Examples
 
-### create-subscription
+### netconf-tool subscription local
 
 This creates a notification event subscription (RFC 5277) and displays the NETCONF payload on the screen, currently doesn't support replay functionality but is useful when developing NETCONF based alerting NMS/applications.
 
 ```bash
-$ netconf-tool create-subscription --host 192.0.2.1
-2023-04-28 22:12:14.299 | INFO     | netconf_tool.cli:cli_create_subscription:85 - Attempting to establish NETCONF session to 192.0.2.1:830
-2023-04-28 22:12:14.662 | SUCCESS  | netconf_tool.cli:cli_create_subscription:95 - Established NETCONF connection to 192.0.2.1:830 (Session ID: 43)
-2023-04-28 22:12:14.770 | SUCCESS  | netconf_tool.cli:cli_create_subscription:99 - Created Netconf Subscription, you can exit out of here using Ctrl+C
-2023-04-28 22:12:14.770 | INFO     | netconf_tool.cli:cli_create_subscription:105 - Awaiting next NETCONF <notification/>
-2023-04-28 22:12:23.035 | INFO     | netconf_tool.cli:cli_create_subscription:108 - <?xml version="1.0" encoding="UTF-8"?>
+$ netconf-tool subscription local --host 192.0.2.1
+2023-04-28 22:12:14.299 | INFO     | netconf_tool.subscription.local:cli_subscription_local:18 - Attempting to establish NETCONF session to 192.0.2.1:830
+2023-04-28 22:12:14.662 | SUCCESS  | netconf_tool.subscription.local:cli_subscription_local:28 - Established NETCONF connection to 192.0.2.1:830 (Session ID: 43)
+2023-04-28 22:12:14.770 | SUCCESS  | netconf_tool.subscription.local:cli_subscription_local:32 - Created Netconf Subscription, you can exit out of here using Ctrl+C
+2023-04-28 22:12:14.770 | INFO     | netconf_tool.subscription.local:cli_subscription_local:38 - Awaiting next NETCONF <notification/>
+2023-04-28 22:12:23.035 | INFO     | netconf_tool.subscription.local:cli_subscription_local:41 - <?xml version="1.0" encoding="UTF-8"?>
 <notification xmlns="urn:ietf:params:xml:ns:netconf:notification:1.0">
   <eventTime>2023-04-28T22:12:22Z</eventTime>
   <netconf-config-change xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-notifications">
@@ -53,14 +56,69 @@ $ netconf-tool create-subscription --host 192.0.2.1
 </notification>
 ```
 
-### list-server-capabilities
+### netconf-tool subscription redis-pubsub
+
+Similar to `netconf-tool subscription local` however sends the NETCONF notification/event to a Redis pubsub channel.
+
+```bash
+$ netconf-tool subscription redis-pubsub --host 192.0.2.1
+2023-04-29 17:32:55.350 | INFO     | netconf_tool.subscription.redis:cli_subscription_redis_pubsub:35 - Checking if Redis server 127.0.0.1:6379 is available
+2023-04-29 17:32:55.374 | SUCCESS  | netconf_tool.subscription.redis:cli_subscription_redis_pubsub:39 - Redis server is available...
+2023-04-29 17:32:55.374 | INFO     | netconf_tool.subscription.redis:cli_subscription_redis_pubsub:44 - Attempting to establish NETCONF session to 192.0.2.1:830
+2023-04-29 17:32:55.725 | SUCCESS  | netconf_tool.subscription.redis:cli_subscription_redis_pubsub:55 - Established NETCONF connection to 192.0.2.1:830 (Session ID: 117)
+2023-04-29 17:32:55.832 | SUCCESS  | netconf_tool.subscription.redis:cli_subscription_redis_pubsub:59 - Created Netconf Subscription, you can exit out of here using Ctrl+C
+2023-04-29 17:32:55.833 | INFO     | netconf_tool.subscription.redis:cli_subscription_redis_pubsub:65 - Awaiting next NETCONF <notification/>
+```
+
+Example using redis-cli
+```
+$ redis-cli
+127.0.0.1:6379> subscribe netconf_tool:all_events
+Reading messages... (press Ctrl-C to quit)
+1) "subscribe"
+2) "netconf_tool:all_events"
+3) (integer) 1
+1) "message"
+2) "netconf_tool:all_events"
+3) "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<notification xmlns=\"urn:ietf:params:xml:ns:netconf:notification:1.0\">\n  <eventTime>2023-04-29T15:24:39Z</eventTime>\n  <netconf-config-change xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-notifications\">\n    <changed-by>\n      <username>netconftool</username>\n      <session-id>0</session-id>\n    </changed-by>\n    <datastore>running</datastore>\n    <edit>\n      <target\n        xmlns:oc-if=\"http://openconfig.net/yang/interfaces\">/oc-if:interfaces/oc-if:interface[name='xe7']/oc-if:config</target>\n      <operation>merge</operation>\n    </edit>\n    <edit>\n      <target\n        xmlns:oc-netinst=\"http://openconfig.net/yang/network-instance\">/oc-netinst:network-instances/oc-netinst:network-instance/oc-netinst:interfaces/oc-netinst:interface</target>\n      <operation>merge</operation>\n    </edit>\n  </netconf-config-change>\n</notification>"
+1) "message"
+2) "netconf_tool:all_events"
+3) "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<notification xmlns=\"urn:ietf:params:xml:ns:netconf:notification:1.0\">\n  <eventTime>2023-04-29T15:24:39Z</eventTime>\n  <severity>critical</severity>\n  <eventClass>state</eventClass>\n  <interface-link-state-change-notification xmlns=\"http://www.ipinfusion.com/yang/ocnos/ipi-interface\">\n    <name>xe7</name>\n    <oper-status>down</oper-status>\n  </interface-link-state-change-notification>\n</notification>"
+```
+
+### netconf-tool subscription rabbitmq
+
+Similar to `netconf-tool subscription local` however sends the NETCONF notification/event to a RabbitMQ Queue.
+
+```bash
+$ netconf-tool subscription rabbitmq --host 192.0.2.1
+2023-04-29 17:35:35.465 | INFO     | netconf_tool.subscription.rabbitmq:cli_subscription_rabbitmq:78 - Checking if RabbitMQ Server 127.0.0.1:5672 is available
+2023-04-29 17:35:35.465 | INFO     | netconf_tool.subscription.rabbitmq:cli_subscription_rabbitmq:82 - Attempting to establish NETCONF session to 192.0.2.1:830
+2023-04-29 17:35:35.831 | SUCCESS  | netconf_tool.subscription.rabbitmq:cli_subscription_rabbitmq:92 - Established NETCONF connection to 192.0.2.1:830 (Session ID: 118)
+2023-04-29 17:35:35.938 | SUCCESS  | netconf_tool.subscription.rabbitmq:cli_subscription_rabbitmq:96 - Created Netconf Subscription, you can exit out of here using Ctrl+C
+2023-04-29 17:35:35.938 | INFO     | netconf_tool.subscription.rabbitmq:cli_subscription_rabbitmq:102 - Awaiting next NETCONF <notification/>
+```
+
+### netconf-tool operations get-config
+
+Simply prints out the returned data using the `get-config` NETCONF operation.
+
+```bash
+$ netconf-tool operations get-config --host 192.0.2.1
+2023-04-29 17:28:48.547 | INFO     | netconf_tool.operations.get_config:cli_operations_get_config:43 - Attempting to establish NETCONF session to 192.0.2.1:830
+2023-04-29 17:28:48.915 | SUCCESS  | netconf_tool.operations.get_config:cli_operations_get_config:53 - Established NETCONF connection to 192.0.2.1:830 (Session ID: 115)
+<?xml version="1.0" ?><data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<ommited>
+```
+
+### netconf-tool operations list-server-capabilities
 
 Prints the server capabilities unless --export-json flag is used, if this flag is used then each capability will be parsed into an RFC3986 compliant object/dictionary and then exported into the relevant filename used in this argument.
 
 ```bash
-$ netconf-tool list-server-capabilities --host 192.0.2.1
-2023-04-28 22:14:39.493 | INFO     | netconf_tool.cli:cli_list_server_capabilities:36 - Attempting to establish NETCONF session to 192.0.2.1:830
-2023-04-28 22:14:39.858 | SUCCESS  | netconf_tool.cli:cli_list_server_capabilities:46 - Established NETCONF connection to 192.0.2.1:830 (Session ID: 45)
+$ netconf-tool operations list-server-capabilities --host 192.0.2.1
+2023-04-29 17:27:59.209 | INFO     | netconf_tool.operations.capabilities:netconf_tool_cli_operations_list_server_capabilities:29 - Attempting to establish NETCONF session to 192.0.2.1:830
+2023-04-29 17:27:59.566 | SUCCESS  | netconf_tool.operations.capabilities:netconf_tool_cli_operations_list_server_capabilities:39 - Established NETCONF connection to 192.0.2.1:830 (Session ID: 113)
 urn:ietf:params:netconf:base:1.0
 urn:ietf:params:netconf:base:1.1
 urn:ietf:params:netconf:capability:candidate:1.0
@@ -72,4 +130,43 @@ urn:ietf:params:netconf:capability:url:1.0?scheme=file,ftp,http
 urn:ietf:params:netconf:capability:notification:1.0
 urn:ietf:params:netconf:capability:interleave:1.0
 urn:ietf:params:netconf:capability:with-defaults:1.0?basic-mode=explicit&also-supported=trim,report-all,report-all-tagged
+```
+
+### netconf-tool yangcli get-config
+
+This command will attempt to lazily build the dynamic XML filter for a provided command in the traditional CLI style, it was inspired by yangcli however doesn't involve YANG at all for any validation, its simply a hack to build the filter if you have an idea of the XML format without having to wrap the text in XML tags. For example if you are trying to just pull the overload-bit configuration from ISIS using Openconfig, then format your CLI command like this:
+
+`network-instances@http://openconfig.net/yang/network-instance network-instance protocols protocol isis global lsp-bit overload-bit config`
+
+Use `@` to include XML Namespaces in your command structure. This simply sets the XML name of the element to` xmlns` and uses the value after the @.
+
+```
+netconf-tool yangcli get-config --host 192.0.2.1 "network-instances@http://openconfig.net/yang/network-instance network-instance protocols protocol isis global lsp-bit overload-bit config"
+2023-04-29 17:40:44.033 | DEBUG    | netconf_tool.yangcli.get_config:netconf_tool_cli_yangcli_get_config:38 - Filter that will be used for get-config: <network-instances xmlns="http://openconfig.net/yang/network-instance"><network-instance><protocols><protocol><isis><global><lsp-bit><overload-bit><config /></overload-bit></lsp-bit></global></isis></protocol></protocols></network-instance></network-instances>
+2023-04-29 17:40:44.034 | INFO     | netconf_tool.yangcli.get_config:netconf_tool_cli_yangcli_get_config:39 - Attempting to establish NETCONF session to 192.0.2.1:830
+2023-04-29 17:40:47.916 | SUCCESS  | netconf_tool.yangcli.get_config:netconf_tool_cli_yangcli_get_config:50 - Established NETCONF connection to 192.0.2.1:830 (Session ID: 22532404)
+<?xml version="1.0" ?><data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"> 
+   <network-instances xmlns="http://openconfig.net/yang/network-instance">  
+     <network-instance>   
+       <name>default</name>   
+       <protocols>    
+         <protocol>     
+           <identifier xmlns:idx="http://openconfig.net/yang/policy-types">idx:ISIS</identifier>     
+           <name>1</name>     
+           <isis>      
+             <global>       
+               <lsp-bit>        
+                 <overload-bit>         
+                   <config>          
+                     <set-bit-on-boot>true</set-bit-on-boot>          
+                   </config>         
+                 </overload-bit>        
+               </lsp-bit>       
+             </global>      
+           </isis>     
+         </protocol>    
+       </protocols>   
+     </network-instance>  
+   </network-instances> 
+ </data>
 ```

--- a/netconf_tool/cli.py
+++ b/netconf_tool/cli.py
@@ -1,13 +1,6 @@
 import click
-import json
 from pkg_resources import iter_entry_points
 from click_plugins import with_plugins
-from ncclient import manager
-from ncclient.transport.errors import SSHError, AuthenticationError
-from loguru import logger
-
-from netconf_tool.decorators import netconf_common_options
-from netconf_tool.helpers import parse_rfc3986_uri
 
 
 @with_plugins(iter_entry_points("netconf_tool.plugins"))
@@ -16,100 +9,5 @@ def cli():
     """CLI Application with plugin based architecture to interact with NETCONF Servers"""
 
 
-@cli.command("list-server-capabilities")
-@click.option(
-    "--export-json",
-    help="Export server capabilities into RFC3986 compliant URIs into a JSON file",
-    type=str,
-)
-@netconf_common_options
-def cli_list_server_capabilities(
-    host: str,
-    port: int,
-    username: str,
-    password: str,
-    device_handler: str,
-    hostkey_verify: bool,
-    export_json: str,
-):
-    """Print or Export all NETCONF Server capabilities"""
-    logger.info(f"Attempting to establish NETCONF session to {host}:{port}")
-    try:
-        with manager.connect(
-            host=host,
-            port=port,
-            username=username,
-            password=password,
-            device_params={"name": device_handler},
-            hostkey_verify=hostkey_verify,
-        ) as m:
-            logger.success(
-                f"Established NETCONF connection to {host}:{port} (Session ID: {m.session_id})"
-            )
-            server_capabilities = m.server_capabilities
-            if not export_json:
-                for capability in server_capabilities:
-                    print(capability)
-                exit()
-
-            capabilities = []
-            for capability in server_capabilities:
-                capability = parse_rfc3986_uri(uri=capability)
-                capabilities.append(capability)
-
-            logger.info(
-                f"Exporting {len(capabilities)} capabilities to JSON file: {export_json}"
-            )
-            with open(export_json, "w") as out_file:
-                json.dump(capabilities, out_file, indent=4)
-    except SSHError as err:
-        logger.error(err)
-    except AuthenticationError as err:
-        logger.error("Unable to authenticate to NETCONF server")
-    except Exception as err:
-        logger.error(f"Generic Exception caught: {err}")
-
-
-@cli.command("create-subscription")
-@netconf_common_options
-def cli_create_subscription(
-    host: str,
-    port: int,
-    username: str,
-    password: str,
-    device_handler: str,
-    hostkey_verify: bool,
-):
-    """Subscribes to notifications/events in real-time and prints them to the screen for debugging/troubleshooting"""
-    logger.info(f"Attempting to establish NETCONF session to {host}:{port}")
-    try:
-        with manager.connect(
-            host=host,
-            port=port,
-            username=username,
-            password=password,
-            device_params={"name": device_handler},
-            hostkey_verify=hostkey_verify,
-        ) as m:
-            logger.success(
-                f"Established NETCONF connection to {host}:{port} (Session ID: {m.session_id})"
-            )
-            m.create_subscription()
-            logger.success(
-                "Created Netconf Subscription, you can exit out of here using Ctrl+C"
-            )
-
-            try:
-                while True:
-                    logger.info("Awaiting next NETCONF <notification/>")
-                    event = m.take_notification()
-
-                    logger.info(event.notification_xml)
-            except KeyboardInterrupt:
-                logger.info("Stopping NETCONF Notification Subscription")
-    except SSHError as err:
-        logger.error(err)
-    except AuthenticationError as err:
-        logger.error("Unable to authenticate to NETCONF server")
-    except Exception as err:
-        logger.error(f"Generic Exception caught: {err}")
+# Import any group commands below here
+from netconf_tool import operations, subscription, yangcli

--- a/netconf_tool/decorators.py
+++ b/netconf_tool/decorators.py
@@ -3,7 +3,28 @@ import functools
 from ncclient.devices import supported_devices_cfg
 
 
-def netconf_common_options(f):
+def common_format_options(f):
+    @click.option(
+        "--format-json",
+        help="If any of the available --export arguments are not used, it will print out the NETCONF payload using xmltodict (JSON)",
+        is_flag=True,
+    )
+    @click.option(
+        "--export-xml",
+        help="The configuration gathered via NETCONF will be created with a filename path of this argument and exported using XML",
+    )
+    @click.option(
+        "--export-json",
+        help="The configuration gathered via NETCONF will be created with a filename path of this argument and exported using xmltodict (JSON)",
+    )
+    @functools.wraps(f)
+    def wrapper_common_options(*args, **kwargs):
+        return f(*args, **kwargs)
+
+    return wrapper_common_options
+
+
+def common_netconf_options(f):
     @click.option(
         "--host",
         help="IP Address of NETCONF Server to connect to",

--- a/netconf_tool/helpers.py
+++ b/netconf_tool/helpers.py
@@ -1,7 +1,14 @@
+from typing import List
 from urllib.parse import urlparse
+from xml.etree import ElementTree
 
 
 def parse_rfc3986_uri(uri: str) -> dict:
+    """Parses a URI (mainly tested with netconf capabilities) and returns a dictionary
+
+    Args:
+        uri:        URI String in the format of RFC3986
+    """
     parsed_uri = urlparse(uri)
     uri_object = parsed_uri._asdict()
     if parsed_uri.query:
@@ -14,3 +21,47 @@ def parse_rfc3986_uri(uri: str) -> dict:
 
         uri_object["queries"] = queries
     return uri_object
+
+
+def build_xml_from_cli_commands(command: str) -> str:
+    """Builds an XML tree from CLI like commands, performs no validation and is a hack function
+
+    Args:
+        command:        CLI like commands (eg. interfaces interface config name)
+    """
+    commands = command.split()
+    root = None
+    previous_element = None
+
+    # Dynamic build XML tree based on the root and previous elements in the list of commands
+    for command in commands:
+        attr = None
+        xmlns = None
+        if "@" in command:
+            command, xmlns = command.split("@")
+
+        if "=" in command:
+            command, attr = command.split("=")
+
+        if root is None:
+            root = ElementTree.Element(command)
+            if attr:
+                root.text = attr
+
+            if xmlns:
+                root.attrib = {"xmlns": xmlns}
+            continue
+
+        if previous_element is None:
+            previous_element = ElementTree.SubElement(root, command)
+        else:
+            previous_element = ElementTree.SubElement(previous_element, command)
+
+        if attr:
+            previous_element.text = attr
+
+        if xmlns:
+            previous_element.attrib = {"xmlns": xmlns}
+
+    command_string = ElementTree.tostring(root, encoding="unicode")
+    return command_string

--- a/netconf_tool/operations/__init__.py
+++ b/netconf_tool/operations/__init__.py
@@ -1,0 +1,9 @@
+from netconf_tool.cli import cli
+
+
+@cli.group("operations")
+def netconf_tool_cli_operations() -> None:
+    """Perform standard NETCONF Operations (get, get-config, edit-config, etc...)"""
+
+
+from netconf_tool.operations import capabilities, get_config

--- a/netconf_tool/operations/capabilities.py
+++ b/netconf_tool/operations/capabilities.py
@@ -1,0 +1,63 @@
+import click
+import json
+from ncclient import manager
+from ncclient.transport.errors import SSHError, AuthenticationError
+from loguru import logger
+
+from netconf_tool.operations import netconf_tool_cli_operations
+from netconf_tool.decorators import common_netconf_options
+from netconf_tool.helpers import parse_rfc3986_uri
+
+
+@netconf_tool_cli_operations.command("list-server-capabilities")
+@common_netconf_options
+@click.option(
+    "--export-json",
+    help="Export server capabilities into RFC3986 compliant URIs into a JSON file",
+    type=str,
+)
+def netconf_tool_cli_operations_list_server_capabilities(
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    device_handler: str,
+    hostkey_verify: bool,
+    export_json: str,
+):
+    """Print or Export all NETCONF Server capabilities"""
+    logger.info(f"Attempting to establish NETCONF session to {host}:{port}")
+    try:
+        with manager.connect(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            device_params={"name": device_handler},
+            hostkey_verify=hostkey_verify,
+        ) as m:
+            logger.success(
+                f"Established NETCONF connection to {host}:{port} (Session ID: {m.session_id})"
+            )
+            server_capabilities = m.server_capabilities
+            if not export_json:
+                for capability in server_capabilities:
+                    print(capability)
+                exit()
+
+            capabilities = []
+            for capability in server_capabilities:
+                capability = parse_rfc3986_uri(uri=capability)
+                capabilities.append(capability)
+
+            logger.info(
+                f"Exporting {len(capabilities)} capabilities to JSON file: {export_json}"
+            )
+            with open(export_json, "w") as out_file:
+                json.dump(capabilities, out_file, indent=4)
+    except SSHError as err:
+        logger.error(err)
+    except AuthenticationError as err:
+        logger.error("Unable to authenticate to NETCONF server")
+    except Exception as err:
+        logger.error(f"Generic Exception caught: {err}")

--- a/netconf_tool/operations/get_config.py
+++ b/netconf_tool/operations/get_config.py
@@ -1,0 +1,101 @@
+import click
+import xmltodict
+import json
+from xml.dom import minidom
+from xml.etree import ElementTree
+from xml.etree.ElementTree import ParseError
+from ncclient import manager
+from ncclient.transport.errors import SSHError, AuthenticationError
+from loguru import logger
+
+from netconf_tool.operations import netconf_tool_cli_operations
+from netconf_tool.decorators import common_format_options, common_netconf_options
+
+
+@netconf_tool_cli_operations.command("get-config")
+@common_netconf_options
+@common_format_options
+@click.option(
+    "--datastore",
+    help="Specify which datastore to retrieve configuration from",
+    type=click.Choice(["running", "candidate"]),
+    default="running",
+)
+@click.option(
+    "--filter", help="Include an XML filter to filter get-config operation", type=str
+)
+def cli_operations_get_config(
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    device_handler: str,
+    hostkey_verify: bool,
+    datastore: str,
+    filter: str,
+    format_json: bool,
+    export_xml: str,
+    export_json: str,
+):
+    """Subscribes to notifications/events in real-time and prints them to the screen for debugging/troubleshooting"""
+    if filter:
+        logger.debug("Performing some basic XML validation")
+        try:
+            ElementTree.fromstring(filter)
+        except ParseError as err:
+            logger.error(f"Parsing error detected with --filter: {err}")
+            exit()
+
+    logger.info(f"Attempting to establish NETCONF session to {host}:{port}")
+    try:
+        with manager.connect(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            device_params={"name": device_handler},
+            hostkey_verify=hostkey_verify,
+        ) as m:
+            logger.success(
+                f"Established NETCONF connection to {host}:{port} (Session ID: {m.session_id})"
+            )
+            if filter:
+                configuration = m.get_config(
+                    source=datastore, filter=("subtree", filter)
+                )
+            else:
+                configuration = m.get_config(source=datastore)
+    except SSHError as err:
+        logger.error(err)
+        exit()
+    except AuthenticationError as err:
+        logger.error("Unable to authenticate to NETCONF server")
+        exit()
+    except Exception as err:
+        logger.error(f"Generic Exception caught: {err}")
+        exit()
+
+    xml_data = minidom.parseString(configuration.data_xml).toprettyxml(
+        indent=" ", newl=""
+    )
+
+    if export_xml:
+        with open(export_xml, "w") as out_file:
+            out_file.write(xml_data)
+        logger.success(f"Exported get-config operation to {export_xml} in XML format")
+        exit()
+
+    if export_json:
+        json_data = xmltodict.parse(xml_data)
+
+        with open(export_json, "w") as out_file:
+            json.dump(json_data, out_file, indent=4)
+
+        logger.success(f"Exported get-config operation to {export_json} in JSON format")
+        exit()
+
+    if format_json:
+        json_data = xmltodict.parse(xml_data)
+        exit(json.dumps(json_data, indent=4))
+
+    exit(xml_data)

--- a/netconf_tool/subscription/__init__.py
+++ b/netconf_tool/subscription/__init__.py
@@ -1,0 +1,9 @@
+from netconf_tool.cli import cli
+
+
+@cli.group("subscription")
+def netconf_tool_cli_subscription() -> None:
+    """Tools to deal with <create-subscription> and NETCONF based events/notifications"""
+
+
+from netconf_tool.subscription import local, rabbitmq, redis

--- a/netconf_tool/subscription/local.py
+++ b/netconf_tool/subscription/local.py
@@ -1,0 +1,53 @@
+from loguru import logger
+from ncclient import manager
+from ncclient.transport.errors import SSHError, AuthenticationError
+from netconf_tool.subscription import netconf_tool_cli_subscription
+from netconf_tool.decorators import common_netconf_options
+
+
+@netconf_tool_cli_subscription.command("local")
+@common_netconf_options
+def cli_subscription_local(
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    device_handler: str,
+    hostkey_verify: bool,
+):
+    """Create a local event listener using <create-subscription> which will simply print out the events to the CLI"""
+    logger.info(f"Attempting to establish NETCONF session to {host}:{port}")
+    try:
+        with manager.connect(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            device_params={"name": device_handler},
+            hostkey_verify=hostkey_verify,
+        ) as m:
+            logger.success(
+                f"Established NETCONF connection to {host}:{port} (Session ID: {m.session_id})"
+            )
+            m.create_subscription()
+            logger.success(
+                "Created Netconf Subscription, you can exit out of here using Ctrl+C"
+            )
+
+            try:
+                while True:
+                    logger.info("Awaiting next NETCONF <notification/>")
+                    event = m.take_notification()
+
+                    logger.info(event.notification_xml)
+            except KeyboardInterrupt:
+                logger.info("Stopping NETCONF Notification Subscription")
+    except SSHError as err:
+        logger.error(err)
+        exit()
+    except AuthenticationError as err:
+        logger.error("Unable to authenticate to NETCONF server")
+        exit()
+    except Exception as err:
+        logger.error(f"Generic Exception caught: {err}")
+        exit()

--- a/netconf_tool/subscription/rabbitmq.py
+++ b/netconf_tool/subscription/rabbitmq.py
@@ -1,0 +1,123 @@
+import click
+import pika
+from pika.exceptions import AMQPConnectionError
+from loguru import logger
+from ncclient import manager
+from ncclient.transport.errors import SSHError, AuthenticationError
+from netconf_tool.subscription import netconf_tool_cli_subscription
+from netconf_tool.decorators import common_netconf_options
+
+
+@netconf_tool_cli_subscription.command("rabbitmq")
+@common_netconf_options
+@click.option(
+    "--rabbitmq-host",
+    help="RabbitMQ Server to connect to",
+    type=str,
+    default="127.0.0.1",
+)
+@click.option(
+    "--rabbitmq-port", help="Port for RabbitMQ server", type=int, default=5672
+)
+@click.option(
+    "--rabbitmq-queue",
+    help="RabbitMQ Queue to create",
+    type=str,
+    default="netconf_tool",
+)
+@click.option("--rabbitmq-exchange", help="RabbitMQ Exchange", type=str, default="")
+@click.option(
+    "--rabbitmq-routing-key",
+    help="RabbitMQ Routing Key",
+    type=str,
+    default="all_events",
+)
+@click.option(
+    "--rabbitmq-username",
+    help="Username to authenticate if authentication is used",
+    type=str,
+)
+@click.option(
+    "--rabbitmq-password",
+    help="Password to authenticate if authentication is used",
+    type=str,
+)
+def cli_subscription_rabbitmq(
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    device_handler: str,
+    hostkey_verify: bool,
+    rabbitmq_host: str,
+    rabbitmq_port: int,
+    rabbitmq_queue: str,
+    rabbitmq_exchange: str,
+    rabbitmq_routing_key: str,
+    rabbitmq_username: str,
+    rabbitmq_password: str,
+):
+    """Create a local event listener using <create-subscription> and redirect to a rabbitmq host"""
+    parameters = pika.ConnectionParameters(rabbitmq_host, rabbitmq_port, "/")
+
+    if rabbitmq_username and rabbitmq_password:
+        parameters.credentials = pika.PlainCredentials(
+            rabbitmq_username, rabbitmq_password
+        )
+
+    try:
+        connection = pika.BlockingConnection()
+    except AMQPConnectionError as err:
+        logger.error(
+            f"Unable to establish connection to RabbitMQ server {rabbitmq_host}:{rabbitmq_password}"
+        )
+        exit()
+    channel = connection.channel()
+    channel.queue_declare(queue=rabbitmq_queue)
+
+    logger.info(
+        f"Checking if RabbitMQ Server {rabbitmq_host}:{rabbitmq_port} is available"
+    )
+
+    logger.info(f"Attempting to establish NETCONF session to {host}:{port}")
+    try:
+        with manager.connect(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            device_params={"name": device_handler},
+            hostkey_verify=hostkey_verify,
+        ) as m:
+            logger.success(
+                f"Established NETCONF connection to {host}:{port} (Session ID: {m.session_id})"
+            )
+            m.create_subscription()
+            logger.success(
+                "Created Netconf Subscription, you can exit out of here using Ctrl+C"
+            )
+
+            try:
+                while True:
+                    logger.info("Awaiting next NETCONF <notification/>")
+                    event = m.take_notification()
+
+                    # Publish to RabbitMQ Queue
+                    data = event.notification_xml
+                    channel.basic_publish(
+                        exchange=rabbitmq_exchange,
+                        routing_key=rabbitmq_routing_key,
+                        body=data,
+                    )
+                    logger.success(f"Published message to RabbitMQ Server:\n{data}")
+            except KeyboardInterrupt:
+                logger.info("Stopping NETCONF Notification Subscription")
+    except SSHError as err:
+        logger.error(err)
+        exit()
+    except AuthenticationError as err:
+        logger.error("Unable to authenticate to NETCONF server")
+        exit()
+    except Exception as err:
+        logger.error(f"Generic Exception caught: {err}")
+        exit()

--- a/netconf_tool/subscription/redis.py
+++ b/netconf_tool/subscription/redis.py
@@ -1,0 +1,81 @@
+import click
+from redis import Redis
+from loguru import logger
+from ncclient import manager
+from ncclient.transport.errors import SSHError, AuthenticationError
+from netconf_tool.subscription import netconf_tool_cli_subscription
+from netconf_tool.decorators import common_netconf_options
+
+
+@netconf_tool_cli_subscription.command("redis-pubsub")
+@common_netconf_options
+@click.option(
+    "--redis-host", help="Redis server to connect to", type=str, default="127.0.0.1"
+)
+@click.option("--redis-port", help="Port for Redis server", type=int, default=6379)
+@click.option(
+    "--redis-channel",
+    help="Channel to publish message to",
+    type=str,
+    default="netconf_tool:all_events",
+)
+def cli_subscription_redis_pubsub(
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    device_handler: str,
+    hostkey_verify: bool,
+    redis_host: str,
+    redis_port: int,
+    redis_channel: str,
+):
+    """Create a local event listener using <create-subscription> and redirect to a redis pubsub channel"""
+    redis = Redis(host=redis_host, port=redis_port)
+    logger.info(f"Checking if Redis server {redis_host}:{redis_port} is available")
+
+    try:
+        redis.ping()
+        logger.success("Redis server is available...")
+    except Exception as err:
+        logger.error(err)
+        exit()
+
+    logger.info(f"Attempting to establish NETCONF session to {host}:{port}")
+
+    try:
+        with manager.connect(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            device_params={"name": device_handler},
+            hostkey_verify=hostkey_verify,
+        ) as m:
+            logger.success(
+                f"Established NETCONF connection to {host}:{port} (Session ID: {m.session_id})"
+            )
+            m.create_subscription()
+            logger.success(
+                "Created Netconf Subscription, you can exit out of here using Ctrl+C"
+            )
+
+            try:
+                while True:
+                    logger.info("Awaiting next NETCONF <notification/>")
+                    event = m.take_notification()
+
+                    data = event.notification_xml
+                    redis.publish(channel=redis_channel, message=data)
+                    logger.success(f"Published message to Redis Server:\n{data}")
+            except KeyboardInterrupt:
+                logger.info("Stopping NETCONF Notification Subscription")
+    except SSHError as err:
+        logger.error(err)
+        exit()
+    except AuthenticationError as err:
+        logger.error("Unable to authenticate to NETCONF server")
+        exit()
+    except Exception as err:
+        logger.error(f"Generic Exception caught: {err}")
+        exit()

--- a/netconf_tool/yangcli/__init__.py
+++ b/netconf_tool/yangcli/__init__.py
@@ -1,0 +1,9 @@
+from netconf_tool.cli import cli
+
+
+@cli.group("yangcli")
+def netconf_tool_cli_yangcli() -> None:
+    """Attempts to build a dynamic XML payload based on a tradtional CLI input"""
+
+
+from netconf_tool.yangcli import get_config

--- a/netconf_tool/yangcli/get_config.py
+++ b/netconf_tool/yangcli/get_config.py
@@ -1,0 +1,92 @@
+import click
+import json
+import xmltodict
+from ncclient import manager
+from ncclient.transport.errors import SSHError, AuthenticationError
+from loguru import logger
+from xml.dom import minidom
+from netconf_tool.yangcli import netconf_tool_cli_yangcli
+from netconf_tool.decorators import common_format_options, common_netconf_options
+from netconf_tool.helpers import build_xml_from_cli_commands
+
+
+@netconf_tool_cli_yangcli.command("get-config")
+@common_netconf_options
+@common_format_options
+@click.argument("command")
+@click.option(
+    "--datastore",
+    help="Specify which datastore to retrieve configuration from",
+    type=click.Choice(["running", "candidate"]),
+    default="running",
+)
+def netconf_tool_cli_yangcli_get_config(
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    device_handler: str,
+    hostkey_verify: bool,
+    command: str,
+    datastore: str,
+    format_json: bool,
+    export_xml: str,
+    export_json: str,
+):
+    """Print or Export all NETCONF Server capabilities - note this command does not perform any validation and is just a test"""
+    filter = build_xml_from_cli_commands(command)
+    if not filter:
+        logger.error("Unable to build XML filter")
+        exit()
+
+    logger.debug(f"Filter that will be used for get-config: {filter}")
+    logger.info(f"Attempting to establish NETCONF session to {host}:{port}")
+
+    try:
+        with manager.connect(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            device_params={"name": device_handler},
+            hostkey_verify=hostkey_verify,
+        ) as m:
+            logger.success(
+                f"Established NETCONF connection to {host}:{port} (Session ID: {m.session_id})"
+            )
+            configuration = m.get_config(source=datastore, filter=("subtree", filter))
+            xml_data = minidom.parseString(configuration.data_xml).toprettyxml(
+                indent=" ", newl=""
+            )
+
+            if export_xml:
+                with open(export_xml, "w") as out_file:
+                    out_file.write(xml_data)
+                logger.success(
+                    f"Exported get-config operation to {export_xml} in XML format"
+                )
+                exit()
+
+            if export_json:
+                json_data = xmltodict.parse(xml_data)
+
+                with open(export_json, "w") as out_file:
+                    json.dump(json_data, out_file, indent=4)
+
+                logger.success(
+                    f"Exported get-config operation to {export_json} in JSON format"
+                )
+                exit()
+
+            if format_json:
+                json_data = xmltodict.parse(xml_data)
+                exit(json.dumps(json_data, indent=4))
+
+            exit(xml_data)
+
+    except SSHError as err:
+        logger.error(err)
+    except AuthenticationError as err:
+        logger.error("Unable to authenticate to NETCONF server")
+    except Exception as err:
+        logger.error(f"Generic Exception caught: {err}")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="netconf_tool",
-    version="0.0.1",
+    version="0.0.2",
     packages=find_packages(exclude=("dev")),
     include_package_data=True,
     description="Click CLI application to help with NETCONF development experience",
@@ -15,6 +15,9 @@ setup(
         "loguru>=0.7.0",
         "click>=8.1.3",
         "click-plugins>=1.1.1",
+        "redis>=4.5.4",
+        "pika>=1.3.1",
+        "xmltodict>=0.13.0",
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
NETCONF Event Notifications can now be sent to either Redis or RabbitMQ for testing purposes

Also first iteration of a lazy CLI to help speed up my development, instead of building XML payloads via scripts or manually, just automatically build the elements using xml module. However this performs no validation against real YANG models which would be cool to work towards in the future...

Also refactored a couple of commands and restructured the command groups/commands (get-config for example being a NETCONF operation, so get, edit-config, rpc operations etc... should be implemented in this folder structure)