### PR TITLE
Allow regex input for get-yang-models

### DIFF
--- a/netconf_tool/operations/get_yang.py
+++ b/netconf_tool/operations/get_yang.py
@@ -1,4 +1,5 @@
 import click
+import re
 from ncclient import manager
 from ncclient.transport.errors import SSHError, AuthenticationError
 from loguru import logger
@@ -17,6 +18,7 @@ from netconf_tool.helpers import parse_rfc3986_uri
     type=str,
     default="./yang_models",
 )
+@click.option("--regex", help="Only match modules with this regex pattern", type=str)
 def cli_operations_get_yang_models(
     host: str,
     port: int,
@@ -26,6 +28,7 @@ def cli_operations_get_yang_models(
     device_handler: str,
     hostkey_verify: bool,
     output_dir: str,
+    regex: str,
 ):
     """Gathers all YANG Models present on the device and writes it to the output directory"""
     output_directory = Path(output_dir)
@@ -33,6 +36,11 @@ def cli_operations_get_yang_models(
         logger.info("Creating output directory and any child folders")
         output_directory.mkdir(parents=True)
 
+    regex_pattern = re.compile(regex)
+    if regex:
+        logger.info(
+            f"Regex pattern detected, will use '{regex_pattern.pattern}' to match YANG modules"
+        )
     yang_modules = []
     n = 0
     logger.info(f"Attempting to establish NETCONF session to {host}:{port}")
@@ -57,6 +65,10 @@ def cli_operations_get_yang_models(
                 ):
                     continue
                 module_name = capability["queries"]["module"]
+                if regex:
+                    if not re.match(regex_pattern, module_name):
+                        continue
+
                 schema = m.get_schema(module_name)
                 file_path = output_directory.joinpath(f"{module_name}.yang")
                 with file_path.open("w") as out_file:

--- a/netconf_tool/operations/get_yang.py
+++ b/netconf_tool/operations/get_yang.py
@@ -18,7 +18,9 @@ from netconf_tool.helpers import parse_rfc3986_uri
     type=str,
     default="./yang_models",
 )
-@click.option("--regex", help="Only match modules with this regex pattern", type=str)
+@click.option(
+    "--regex", help="Only match modules with this regex pattern", type=str, default=""
+)
 def cli_operations_get_yang_models(
     host: str,
     port: int,


### PR DESCRIPTION
As an example, I can now pull only YANG modules from the NETCONF server that relate to `openconfig-platform` with the `get-yang-models` command by using the `--regex` argument.

```
$ netconf-tool operations get-yang-models --host 172.17.0.64 --regex "openconfig-platform"
2023-05-01 10:47:58.275 | INFO     | netconf_tool.operations.get_yang:cli_operations_get_yang_models:41 - Regex pattern detected, will use 'openconfig-platform' to match YANG modules
2023-05-01 10:47:58.275 | INFO     | netconf_tool.operations.get_yang:cli_operations_get_yang_models:46 - Attempting to establish NETCONF session to 172.17.0.64:830
2023-05-01 10:47:58.630 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:57 - Established NETCONF connection to 172.17.0.64:830 (Session ID: 171)
2023-05-01 10:47:58.739 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:78 - Exported module openconfig-platform (yang_models/openconfig-platform.yang)
2023-05-01 10:47:58.846 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:78 - Exported module openconfig-platform-cpu (yang_models/openconfig-platform-cpu.yang)
2023-05-01 10:47:58.953 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:78 - Exported module openconfig-platform-ext (yang_models/openconfig-platform-ext.yang)
2023-05-01 10:47:59.060 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:78 - Exported module openconfig-platform-fan (yang_models/openconfig-platform-fan.yang)
2023-05-01 10:47:59.168 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:78 - Exported module openconfig-platform-linecard (yang_models/openconfig-platform-linecard.yang)
2023-05-01 10:47:59.275 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:78 - Exported module openconfig-platform-port (yang_models/openconfig-platform-port.yang)
2023-05-01 10:47:59.382 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:78 - Exported module openconfig-platform-psu (yang_models/openconfig-platform-psu.yang)
2023-05-01 10:47:59.491 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:78 - Exported module openconfig-platform-transceiver (yang_models/openconfig-platform-transceiver.yang)
2023-05-01 10:47:59.599 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:78 - Exported module openconfig-platform-types (yang_models/openconfig-platform-types.yang)
2023-05-01 10:47:59.705 | SUCCESS  | netconf_tool.operations.get_yang:cli_operations_get_yang_models:90 - Exported a total of 9 YANG models
```